### PR TITLE
feat: add StringSyntax for KeyReference URI parameters

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyReference.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyReference.cs
@@ -10,12 +10,12 @@ namespace System.Security.Cryptography.Xml
             ReferenceType = "KeyReference";
         }
 
-        public KeyReference(string uri) : base(uri)
+        public KeyReference([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("Uri")] string uri) : base(uri)
         {
             ReferenceType = "KeyReference";
         }
 
-        public KeyReference(string uri, TransformChain transformChain) : base(uri, transformChain)
+        public KeyReference([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("Uri")] string uri, TransformChain transformChain) : base(uri, transformChain)
         {
             ReferenceType = "KeyReference";
         }


### PR DESCRIPTION
The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by @fwph & @josephhackman .  Adds `StringSyntaxAttribute("Uri")` to parameters for the `KeyReference` constructors.

This is the first contribution from Permanence, selected from the [Help Wanted list](https://github.com/dotnet/runtime/labels/help%20wanted). Change style adapted from https://github.com/dotnet/runtime/pull/67621. Change has been built and tested, but we have not validated the syntax highlighting as we do not have a version of Roslyn that supports the Uri syntax attribute.

Relates to https://github.com/dotnet/aspnetcore/issues/44535

on-behalf-of: @permanence-ai <github-ai@permanence.ai>